### PR TITLE
学生一覧表示API"返却値に学籍番号のみを追加"

### DIFF
--- a/app/api/koma/StudentsListGet/route.ts
+++ b/app/api/koma/StudentsListGet/route.ts
@@ -39,16 +39,19 @@ export const GET = async (req: NextApiRequest, res: NextApiResponse) => {
         },
         select: {           // 表示するフィールドを指定する
           name: true,
-          email: true,
-          studentProfile: true, // プロフィール
-          record: true,         // カルテ情報
-          booking: true,        // 面談予約情報
+          // email: true,
+          // studentProfile: true, // プロフィール
+          // record: true,         // カルテ情報
+          // booking: true,        // 面談予約情報
         },
       });
 
       if (user.length > 0) {
         return NextResponse.json(
-          { message: "Success", user },
+          { message: "Success",
+            searchValue,        // 学籍番号
+            user                // 学生情報(nameOnly)
+          },
           { status: 200 }
         );
       } else {


### PR DESCRIPTION
学生一覧をsつ要する際の返却値を、
"学生名、EmailAddress、プロフィール、カルテ情報、面談予約情報"から
"学生名、学籍番号"に更新。
現在取得できる学生情報は、ハードコーディングした学籍番号を含むアドレスで登録されたUserのみ。