### PR TITLE
教員側の学生一覧取得画面のフォルダ移行とレコードlink追加

### DIFF
--- a/app/(root)/staff/students/page.tsx
+++ b/app/(root)/staff/students/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import Link from 'next/link';
 
 interface User {
   id: number | string;
@@ -15,9 +16,11 @@ const Students = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [filteredUsers, setFilteredUsers] = useState<User[]>([]);
   // console.log(user);
+
   useEffect(() => {
     // 学生一覧を取得するAPIのエンドポイント
-    const apiEndpoint = '/api/koma/StudentsListGet';
+    // const apiEndpoint = '/api/koma/StudentsListGet';
+    const apiEndpoint = '/api/staff/students';
 
     // APIから学生一覧を取得
     const fetchStudents = async () => {
@@ -41,6 +44,8 @@ const Students = () => {
     setFilteredUsers(filtered);
   }, [searchTerm, user]);
 
+
+  // 検索欄の入力値が変更された時に画面に更新結果を反映するコンポーネント
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(event.target.value);
   };
@@ -76,14 +81,17 @@ const Students = () => {
 
         <div className="m-5 flex flex-wrap justify-center items-center">
           {filteredUsers.map((user) => (
+          // <Link key={user.id} href={`../staff/record/${user.id}`}>
+          <Link key={user.id} href={`../staff/record/`}>
             <button
-              key={user.id}
+              // key={user.id}
               className={'my-2 mx-5 min-w-[24ch] px-8 p-5 border-2 bg-white border-gray-100 shadow-md rounded-lg hover:border-2 hover:border-kd-sub2-cl overflow-hidden'}
               title={user.name}
             >
               {user.name.length > 8 ? user.name.slice(0, 8) + '...' : user.name}<br />
               学籍番号：{user.studentIdNumber}
             </button>
+          </Link>
           ))}
         </div>
       </div>

--- a/app/api/staff/students/route.ts
+++ b/app/api/staff/students/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";               // APIミドルウェアでレスポンスを操作するためのオブジェクト
+import { PrismaClient } from "@prisma/client";            // データベース接続とクエリのためのメインオブジェクト
+// import getStaffUsers from "@/app/actions/getStaffUsers";  //教員のセッション情報認証ロジックをインポート
+// import getUserMail from "@/app/actions/getUserMail";      //ユーザーのセッション情報認証ロジックをインポート
+
+const prisma = new PrismaClient();                        // prisma clientのインスタンス生成
+
+
+// DB接続関数の定義
+export async function main() {
+  try {
+    await prisma.$connect();    // DBに接続
+  } catch (err) {
+    return Error("DB接続に失敗しました");
+  }
+}
+
+// 学生一覧を取得するAPI
+export const GET = async (req: Request, res: NextResponse) => {
+  console.log("GET All Students");
+  try{
+    await main(); // DB接続関数の呼び出し
+    const user = await prisma.user.findMany({
+      where: { role: "student" },  // 学生のみを検索対象とする
+      select: {
+        name: true,
+        email: true,
+      },
+    })
+
+    // emailから数値の部分(学籍番号)のみを取り出す部品
+    const transformedUsers = user.map(user => ({
+      studentIdNumber:
+        user.email ?                          // nullチェックを行い、以下のreplaceメソッドを安全に呼び出す
+        user.email.replace(/\D/g, '') : "",   // \D: 数字以外を表す正規表現
+      name: user.name,
+      // email: user.email,
+    }));
+
+    // 成功時のレスポンス
+    return NextResponse.json(
+      { message: "Success", users: transformedUsers, },
+      { status: 200 }           // ステータスコード all OK
+    );
+  } catch (err) {
+    console.error("Error:", err);   // エラー時の確認用ログ出力
+    return NextResponse.json({ message: "Error", err }, { status: 500 });
+  } finally {
+    await prisma.$disconnect(); // DBへの接続を解除
+  }
+};


### PR DESCRIPTION
タイトル通りです。
開発用のkoma/フォルダから本番用の(root)/staff/students/に対応するエンドポイントを、(root)/api/staff/students/に移動しました。
画面内では学生をクリックすることでrecordに遷移するように更新しました。