### PR TITLE
fix: nonominationlistでPOSTの処理を修正

### DIFF
--- a/app/api/staff/approvallist/nonominationList/route.ts
+++ b/app/api/staff/approvallist/nonominationList/route.ts
@@ -6,12 +6,8 @@ import getUserId from "@/app/actions/getUserId";
 // Bookingコレクションに情報を登録するAPI
 export const POST = async (req: Request, res: NextResponse) => {
   try {
-    const { id, staffName, studentUserId, ymd, time, details } =
+    const { id, staffUserId, staffName, studentUserId, ymd, time, details } =
       await req.json();
-
-    // 職員のユーザーIDを取得する
-    const userMail = await getUserMail();
-    const staffUserId = await getUserId(userMail);
 
     // すでに同じ時間帯に予定が存在しているかの判定
     const BookingData = await prisma.booking.findMany({


### PR DESCRIPTION
nonominationlistのPOSTの中で、職員が指名されていない予定を承認する際に、選択された職員の名前を保存する処理はできているものの、職員のidを保存する時に選択された職員のidではなく、画面を操作している職員のidが保存されてしまっていたので修正しました。