### PR TITLE
fix: nonominationlistに合わせて修正

### DIFF
--- a/app/api/staff/approvallist/route.ts
+++ b/app/api/staff/approvallist/route.ts
@@ -95,6 +95,7 @@ export const GET = async (req: Request, res: NextResponse) => {
     const staffUserList = await prisma.user.findMany({
       where: { role: "staff" },
       select: {
+        id: true,
         name: true,
       },
     });


### PR DESCRIPTION
nonominationlistで指名なしの予定を承認して保存する際に、選択された職員の名前は反映され、選択された職員の名前が保存されるものの、職員idは画面を操作している職員のidが保存されてしまう問題を修正するために、applovallistのGETですべての職員の名前を取得する処理の部分にidも返すように修正しました。